### PR TITLE
Fix #14: scrub invalid UTF-8 bytes from LaTeX log lines

### DIFF
--- a/bin/texqc
+++ b/bin/texqc
@@ -85,8 +85,9 @@ begin
       /^Package \S+ Warning: /,
       /^LaTeX Font Warning: /
     ]
-    File.open(f) do |io|
+    File.open(f, 'rb') do |io|
       io.each_line.with_index do |t, i|
+        t = t.force_encoding('UTF-8').scrub
         matches.each do |p|
           next unless p.match?(t)
           next if opts[:ignore].any? { |re| /.*#{re}.*/.match?(t) }

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -73,3 +73,13 @@ Feature: Command Line Processing
     """
     Then I run bin/texqc with "article"
     Then Exit code is zero
+
+  Scenario: A log with invalid UTF-8 bytes is processed without crashing
+    Given I have a "article.log" file with content:
+    """
+    Some unrelated line with a bad byte: \xFF here
+    LaTeX Warning: Label `xxx' multiply defined.
+    """
+    Then I run bin/texqc with "article"
+    Then Exit code is not zero
+    And Stdout contains "1 LaTeX processing errors"

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -20,7 +20,7 @@ end
 
 Given(/^I have a "([^"]*)" file with content:$/) do |file, text|
   FileUtils.mkdir_p(File.dirname(file)) unless File.exist?(file)
-  File.write(file, text.gsub('\\xFF', 0xFF.chr))
+  File.binwrite(file, text.gsub('\\xFF', 0xFF.chr))
 end
 
 When(%r{^I run bin/texqc with "([^"]*)"$}) do |arg|


### PR DESCRIPTION
@yegor256 — closes #14.

**Problem.** Some LaTeX `.log` files contain bytes that are not valid UTF-8 (binary content emitted by certain packages, non-UTF-8 source encodings, etc.). When `texqc` scanned such a file, `Regexp#match?` on a line with bad bytes raised `ArgumentError: invalid byte sequence in UTF-8` and aborted the run with exit code 255.

**Fix.** `bin/texqc` now opens the log in binary mode and `force_encoding`s + `scrub`s each line before pattern matching, so invalid bytes are replaced with `?` instead of crashing `match?`. The file is treated as a stream of bytes — the patterns that texqc cares about (`Underfull`, `Overfull`, `LaTeX Warning:`, `pdfTeX warning:`, `Class/Package … Warning:`, `LaTeX Font Warning:`) are all plain ASCII, so scrubbing has no effect on detection accuracy.

**Test.** Added a Cucumber scenario (`features/cli.feature`) that writes a log containing a `\xFF` byte alongside a real `LaTeX Warning:` line and asserts the tool reports the warning instead of crashing. Adjusted the file-writing step to use `File.binwrite` so scenarios can embed raw bytes (the previous `File.write` produced an `Encoding::UndefinedConversionError` when given a non-UTF-8 byte, which is why this case was never covered before).

**Verification.**
- `bundle exec rake` (cucumber + rubocop) passes locally.
- All meaningful CI workflows are green on my fork at the same SHA: rake on Ubuntu / macOS / Windows, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint — see https://github.com/bibonix/texqc/actions?query=branch%3Amaster.
- The CI checks on this PR are stuck in the GitHub _action_required_ state because I am a first-time contributor; they need your approval to run on the upstream side. The codecov workflow is unrelated to this fix and runs only on `push: master`.

Files changed:
- `bin/texqc`: scrub invalid bytes per line.
- `features/cli.feature`: new scenario covering bad UTF-8 bytes in the log.
- `features/step_definitions/steps.rb`: switch to `File.binwrite` so the `\\xFF` substitution actually round-trips to disk.